### PR TITLE
build-fx: Use pre-config-hook to install meson wrap dependencies

### DIFF
--- a/build_master.json
+++ b/build_master.json
@@ -7,6 +7,7 @@
     "debug_defines": [ "-DPVK_DEBUG" ],
     "install_header_dirs" : [ "include/PlayVk" ],
     "include_dirs" : [ "include" ],
+    "pre_config_hook" : "install_meson_wraps.sh",
     "vars":
     {
         "vulkan_sdk_path" : "run_command(find_program('python'), '-c', 'import os; print(os.environ[\"VK_SDK_PATH\"])', check : false).stdout().strip()",

--- a/install_meson_wraps.sh
+++ b/install_meson_wraps.sh
@@ -1,0 +1,8 @@
+#! /usr/bin/bash
+
+if [ ! -f 'subprojects/glfw.wrap' ]; then
+	meson wrap install glfw
+fi
+if [ ! -f 'subprojects/vulkan-headers.wrap' ]; then
+	meson wrap install vulkan-headers
+fi

--- a/meson.build
+++ b/meson.build
@@ -121,15 +121,15 @@ add_project_link_arguments('-m64', link_args_bm_internal__, language : 'c')
 add_project_link_arguments('-m64', link_args_bm_internal__, language : 'cpp')
 
 # Build type specific defines
-build_mode_defines_bm_internal__ = defines_bm_internal__
+project_build_mode_defines_bm_internal__ = defines_bm_internal__
 if get_option('buildtype') == 'release'
   add_project_arguments(release_defines_bm_internal__, language : 'c')
   add_project_arguments(release_defines_bm_internal__, language : 'cpp')
-  build_mode_defines_bm_internal__ += release_defines_bm_internal__
+  project_build_mode_defines_bm_internal__ += release_defines_bm_internal__
 else
   add_project_arguments(debug_defines_bm_internal__, language : 'c')
   add_project_arguments(debug_defines_bm_internal__, language : 'cpp')
-  build_mode_defines_bm_internal__ += debug_defines_bm_internal__
+  project_build_mode_defines_bm_internal__ += debug_defines_bm_internal__
 endif
 
 # pkg-config package installation
@@ -191,7 +191,7 @@ playvk_headers_use_defines_bm_internal__ = [
 ]
 playvk_headers_dep = declare_dependency(
 	include_directories: [inc_bm_internal__, playvk_headers_include_dirs_bm_internal__],
-	compile_args: playvk_headers_use_defines_bm_internal__ + build_mode_defines_bm_internal__
+	compile_args: playvk_headers_use_defines_bm_internal__ + project_build_mode_defines_bm_internal__
 )
 pkgmod.generate(	name: 'PlayVk',
 	description: 'Single header file library for simplifying vulkan',
@@ -200,7 +200,7 @@ pkgmod.generate(	name: 'PlayVk',
 	subdirs: [
 'PlayVk'
 ]
-, 	extra_cflags: playvk_headers_use_defines_bm_internal__ + build_mode_defines_bm_internal__
+, 	extra_cflags: playvk_headers_use_defines_bm_internal__ + project_build_mode_defines_bm_internal__
 )
 
 # -------------- Target: main ------------------
@@ -226,8 +226,8 @@ main = executable('main',
 	dependencies: dependencies_bm_internal__ + main_dependencies_bm_internal__,
 	include_directories: [inc_bm_internal__, main_include_dirs_bm_internal__],
 	install: false,
-	c_args: main_defines_bm_internal__,
-	cpp_args: main_defines_bm_internal__, 
+	c_args: main_defines_bm_internal__ + project_build_mode_defines_bm_internal__,
+	cpp_args: main_defines_bm_internal__ + project_build_mode_defines_bm_internal__, 
 	link_args: main_link_args_bm_internal__[host_machine.system()],
 	gnu_symbol_visibility: 'hidden'
 )
@@ -237,4 +237,5 @@ main = executable('main',
 #--------------------------------Header Intallation----------------------------------
 # Header installation
 install_subdir('include/PlayVk', install_dir : get_option('includedir'))
+
 


### PR DESCRIPTION
- This fixes fresh clone and build.